### PR TITLE
Http and gemini content fetching

### DIFF
--- a/tools/fetch_remote_content/Cargo.toml
+++ b/tools/fetch_remote_content/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 readability = "^0"
+poptea = "^0"

--- a/tools/fetch_remote_content/src/main.rs
+++ b/tools/fetch_remote_content/src/main.rs
@@ -1,16 +1,45 @@
-use std::env;
-use std::io;
+use std::{
+    env, io, str,
+    sync::{Arc, Mutex},
+};
 extern crate readability;
+use poptea::{GeminiClient, NoTrustStore};
 use readability::extractor;
 
+fn get_http(url: &str) -> Result<String, Box<dyn std::error::Error>> {
+    Ok(extractor::scrape(url)?.text)
+}
+
+fn get_gemini(url: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let gemini_response = poptea::TlsClient::new(Arc::new(Mutex::new(NoTrustStore::default())))
+        .get(url)
+        .map_err(|e| e.to_string())?;
+    Ok(gemini_response
+        .body
+        .map(String::from_utf8)
+        .ok_or("no content")?
+        .map_err(|e| e.to_string())?)
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = env::args().nth(1).ok_or_else(|| {
-        Box::new(io::Error::new(
-            io::ErrorKind::Other,
-            "a single argument is required",
-        ))
-    })?;
-    let product = extractor::scrape(&url)?;
-    println!("{}", product.text);
+    let url = env::args()
+        .nth(1)
+        .ok_or_else(|| fetch_remote_err("a single argument is required"))?;
+
+    let archive_text = match url
+        .split_once("://")
+        .ok_or_else(|| fetch_remote_err("scheme not provided"))?
+    {
+        ("https" | "http", _) => get_http(&url)?,
+        ("gemini", _) => get_gemini(&url)?,
+        _ => return Err("unsuported protocol".into()),
+    };
+
+    println!("{}", archive_text);
+
     Ok(())
+}
+
+fn fetch_remote_err(e: &str) -> Box<io::Error> {
+    Box::new(io::Error::new(io::ErrorKind::Other, e))
 }


### PR DESCRIPTION
`fetch_remote_content` tool now can get http and gemini content. 

With these changes `fetch_remote_content` command naively parses url schema and either fetches http and gemini content or returns an error.

I'm not sure about the required python changes in here https://github.com/epilys/sic/blob/ed0c162a5700d5e41cf66258356c9d8f2d8b8446/sic/jobs.py#L33 

@epilys could you take a look at this branch and verify that nothing is broken?